### PR TITLE
[bandcamp] fix regexp for JSON matching on bandcamp

### DIFF
--- a/youtube_dl/extractor/bandcamp.py
+++ b/youtube_dl/extractor/bandcamp.py
@@ -91,10 +91,11 @@ class BandcampIE(InfoExtractor):
         duration = None
 
         formats = []
-        track_info = self._parse_json(
-            self._search_regex(
-                r'trackinfo\s*:\s*\[\s*({.+?})\s*\]\s*,\s*?\n',
-                webpage, 'track info', default='{}'), title)
+        trackinfo_block = self._search_regex(
+            r'trackinfo&quot;:\[\s*({.+?})\s*\],&quot;',
+            webpage, 'track info', default='{}')
+        quoted_json = trackinfo_block.replace('&quot;', '"')
+        track_info = self._parse_json(quoted_json, title)
         if track_info:
             file_ = track_info.get('file')
             if isinstance(file_, dict):
@@ -117,7 +118,7 @@ class BandcampIE(InfoExtractor):
 
         def extract(key):
             return self._search_regex(
-                r'\b%s\s*["\']?\s*:\s*(["\'])(?P<value>(?:(?!\1).)+)\1' % key,
+                r',&quot;%s&quot;:(&quot;)(?P<value>(?:(?!&quot;).)+)&quot;' % key,
                 webpage, key, default=None, group='value')
 
         artist = extract('artist')


### PR DESCRIPTION
Bandcamp changed their JSON format using " entities all over, so this tries to match it so that youtube-dl can get the track info and work its magic.